### PR TITLE
Minimal URI escaping

### DIFF
--- a/src/thumbnailer.rs
+++ b/src/thumbnailer.rs
@@ -155,14 +155,19 @@ impl Thumbnailer {
             }
             format!("file://{}", encoded)
         } else {
-            percent_encoding::utf8_percent_encode(
+            let segment = percent_encoding::utf8_percent_encode(
                 path.file_name().unwrap().to_str().unwrap(),
                 // Could just as well pick pchar, and while arguably it'd be more correct, no need
                 // to lug around two tables as practically the path is guaranteed not to contain a
                 // slash.
                 &PATH_TO_FILEURI,
-            )
-            .to_string()
+            ).to_string();
+
+            if segment.contains(':') {
+                format!("./{}", segment)
+            } else {
+                segment
+            }
         }
     }
 

--- a/src/thumbnailer.rs
+++ b/src/thumbnailer.rs
@@ -329,6 +329,41 @@ mod tests {
     }
 
     #[test]
+    fn test_exotic_encodings() {
+        let with_space = Path::new("/home/jens/my photos/hello world.png").to_owned();
+        assert_eq!(
+            Thumbnailer::calculate_path_uri(true, &with_space),
+            "file:///home/jens/my%20photos/hello%20world.png"
+        );
+        assert_eq!(
+            Thumbnailer::calculate_path_uri(false, &with_space),
+            "hello%20world.png"
+        );
+
+        let with_colon = Path::new("/home/jens/hello:world.png").to_owned();
+        assert_eq!(
+            Thumbnailer::calculate_path_uri(true, &with_colon),
+            "file:///home/jens/hello:world.png"
+        );
+        assert_eq!(
+            Thumbnailer::calculate_path_uri(false, &with_colon),
+            "./hello:world.png"
+        );
+
+        // Tests both for some that should be escaped, and for whether capitalization of the
+        // percent encoding is upper case
+        let some_other_odd = Path::new("/home/jens/hello[w]orld-percent%sign-question?mark.png").to_owned();
+        assert_eq!(
+            Thumbnailer::calculate_path_uri(true, &some_other_odd),
+            "file:///home/jens/hello%5Bw%5Dorld-percent%25sign-question%3Fmark.png"
+        );
+        assert_eq!(
+            Thumbnailer::calculate_path_uri(false, &some_other_odd),
+            "hello%5Bw%5Dorld-percent%25sign-question%3Fmark.png"
+        );
+    }
+
+    #[test]
     fn test_new() {
         let input_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
             .join("test_resources")


### PR DESCRIPTION
**Warning**: This is based on a not-yet-concluded specification precision suggestion. You might not want to merge this until the discussion there is concluded; this serves to illustrate, and as a reference implementation of the proposed canonicalization.

There is some over-escaping happening currently before the MD5 hashing; in particular, a colon (':') is escaped without need.

While discussion is ongoing at [FDO](https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/29#note_1037277) and there may be follow-ups [on the IETF side](https://mailarchive.ietf.org/arch/msg/art/U3aGPqA5ZeGu4afknVjzMcoO5ho), I think that what is proposed here is what should be the canonical encoding.

Concrete changes:
* The to-be-escaped set is changed from the illegal characters of the userinfo component (of which I don't understand why it was picked for here) to the set described by the allowed characters in a path segment (named `pchar` in [RFC3986](https://www.rfc-editor.org/rfc/rfc3986.html), and imported from [RFC8089](https://www.rfc-editor.org/rfc/rfc8089.html) via the `path-absolute` rule.
* A `./` prefix is introduced iff there is a colon in the relative reference. (Otherwise URI parsing would give completely different results when parsed back).
* Tests to capture the new behavior. (The existing tests didn't even notice the changes).